### PR TITLE
Error when starting a rails app

### DIFF
--- a/lib/rakismet/railtie.rb
+++ b/lib/rakismet/railtie.rb
@@ -9,9 +9,9 @@ module Rakismet
       config.rakismet.use_middleware = true
 
       initializer 'rakismet.setup', :after => :load_config_initializers do |app|
-        Rakismet.key = app.config.rakismet.key
-        Rakismet.url = app.config.rakismet.url
-        Rakismet.host = app.config.rakismet.host
+        Rakismet.key = app.config.rakismet[:key]
+        Rakismet.url = app.config.rakismet[:url]
+        Rakismet.host = app.config.rakismet[:host]
         app.middleware.use Rakismet::Middleware if app.config.rakismet.use_middleware
       end
 


### PR DESCRIPTION
I get an error about the 'key' method requiring an argument whenever I start my application.

This happens because when it calls the method 'key' it doesn't go to check the attribute 'key' but rather it calls the actual hash method 'key' which requires an argument.

This fixes the access to use regular hash syntax instead. If there's anywhere else this needs to be fixed just let me know as well!
