### PR TITLE
undefined method `bytesize' for nil:NilClass in Rails 3.0.8 and 3.0.9

### DIFF
--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -55,7 +55,7 @@ module Rakismet
       args.merge!(:blog => Rakismet.url)
       akismet = URI.parse(call_url(function))
       _, response = Net::HTTP::Proxy(proxy_host, proxy_port).start(akismet.host) do |http|
-        data = args.map { |k,v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        data = args.map { |k,v| "#{k}=#{CGI.escape(v.to_str)}" }.join('&')
         http.post(akismet.path, data, Rakismet.headers)
       end
       response


### PR DESCRIPTION
Ran into a problem when passing a Safebuffer string to Rakismet in rails 3.08 and 3.09. Essentially finding that it'd cause an exception when it tried the CGI.escape (which returns nil on a Safebuffer string). 

I originally reported the issue here: https://github.com/rails/rails/issues/1739

Anyway, the solution was to change the to_s (returns self when it's a Safebuffer) to a to_str (returns an unsafe copy for the string when it's a Safebuffer). 

Have this currently running in production for our use case - can't speak on how this might affect others. 

Thanks!
-Brandon
