### PR TITLE
Fix deprecated usage of HTTPResponse for 1.9.3

### DIFF
--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -39,11 +39,11 @@ module Rakismet
     def validate_key
       validate_config
       akismet = URI.parse(verify_url)
-      _, valid = Net::HTTP::Proxy(proxy_host, proxy_port).start(akismet.host) do |http|
+      response = Net::HTTP::Proxy(proxy_host, proxy_port).start(akismet.host) do |http|
         data = "key=#{Rakismet.key}&blog=#{Rakismet.url}"
         http.post(akismet.path, data, Rakismet.headers)
       end
-      @valid_key = (valid == 'valid')
+      @valid_key = (response.body == 'valid')
     end
 
     def valid_key?
@@ -54,14 +54,14 @@ module Rakismet
       validate_config
       args.merge!(:blog => Rakismet.url)
       akismet = URI.parse(call_url(function))
-      _, response = Net::HTTP::Proxy(proxy_host, proxy_port).start(akismet.host) do |http|
+      response = Net::HTTP::Proxy(proxy_host, proxy_port).start(akismet.host) do |http|
         params = args.map do |k,v|
           param = v.class < String ? v.to_str : v.to_s # for ActiveSupport::SafeBuffer and Nil, respectively
           "#{k}=#{CGI.escape(param)}"
         end
         http.post(akismet.path, params.join('&'), Rakismet.headers)
       end
-      response
+      response.body
     end
 
     protected

--- a/spec/rakismet_spec.rb
+++ b/spec/rakismet_spec.rb
@@ -2,7 +2,10 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe Rakismet do
 
-  let(:http) { double(:http, :to_ary => [nil, 'akismet response']).as_null_object }
+  def mock_response(body)
+    double(:response, :body => body)
+  end
+  let(:http) { double(:http, :post => mock_response('akismet response')) }
 
   after do
     Rakismet.key = 'dummy-key'
@@ -43,19 +46,19 @@ describe Rakismet do
     it "should use proxy host and port" do
       Rakismet.proxy_host = 'proxy_host'
       Rakismet.proxy_port = 'proxy_port'
-      @proxy.stub!(:start).and_return([nil, 'valid'])
+      @proxy.stub!(:start).and_return(mock_response('valid'))
       Net::HTTP.should_receive(:Proxy).with('proxy_host', 'proxy_port').and_return(@proxy)
       Rakismet.validate_key
     end
     
     it "should set @@valid_key = true if key is valid" do
-      @proxy.stub!(:start).and_return([nil, 'valid'])
+      @proxy.stub!(:start).and_return(mock_response('valid'))
       Rakismet.validate_key
       Rakismet.valid_key?.should be_true
     end
 
     it "should set @@valid_key = false if key is invalid" do
-      @proxy.stub!(:start).and_return([nil, 'invalid'])
+      @proxy.stub!(:start).and_return(mock_response('invalid'))
       Rakismet.validate_key
       Rakismet.valid_key?.should be_false
     end
@@ -78,7 +81,7 @@ describe Rakismet do
     it "should use proxy host and port" do
       Rakismet.proxy_host = 'proxy_host'
       Rakismet.proxy_port = 'proxy_port'
-      @proxy.stub!(:start).and_return([nil, 'valid'])
+      @proxy.stub!(:start).and_return(mock_response('valid'))
       Net::HTTP.should_receive(:Proxy).with('proxy_host', 'proxy_port').and_return(@proxy)
       Rakismet.send(:akismet_call, 'bogus-function')
     end


### PR DESCRIPTION
Hey,

I figured out that the way you're using response (by implicitly converting it into an array) does not work in 1.9.3. It's a freaking subtle bug, because [the syntax](https://github.com/joshfrench/rakismet/blob/022608584b453d30415d446619cb9017b35fd468/lib/rakismet.rb#L42) still works without any warnings, but the second variable does not get assigned.

Your specs didn't catch it, because you're using the wrong (deprecated) mocks.

The code didn't break, it just never detected any spam response.

And it's a trivial fix _if_ you know about [the deprecation](http://ruby-doc.org/stdlib-1.9.2/libdoc/net/http/rdoc/Net/HTTPResponse.html#method-i-to_ary).

Whew. Spent a couple of hours tracking this down.
