### PR TITLE
Add user_role to Rakismet model attributes.

### DIFF
--- a/lib/rakismet/model.rb
+++ b/lib/rakismet/model.rb
@@ -1,6 +1,6 @@
 module Rakismet
   module Model
-   
+
     def self.included(base)
       base.class_eval do
         attr_accessor :akismet_response
@@ -10,11 +10,11 @@ module Rakismet
         self.rakismet_attrs
       end
     end
-   
+
     module ClassMethods
       def rakismet_attrs(args={})
         self.akismet_attrs ||= {}
-        [:comment_type, :author, :author_url, :author_email, :content].each do |field|
+        [:comment_type, :author, :author_url, :author_email, :content, :user_role].each do |field|
           # clunky, but throwing around +type+ will break your heart
           fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
           self.akismet_attrs[fieldname] = args.delete(field) || field
@@ -32,7 +32,7 @@ module Rakismet
         subclass.rakismet_attrs akismet_attrs.dup
       end
     end
-    
+
     module InstanceMethods
       def spam?
         if instance_variable_defined? :@_spam
@@ -64,7 +64,8 @@ module Rakismet
                                 elsif !mapped_field.nil? && respond_to?(mapped_field)
                                   send(mapped_field)
                                 elsif not [:comment_type, :author, :author_email,
-                                        :author_url, :content, :user_ip, :referrer,
+                                        :author_url, :content, :user_role,
+                                        :user_ip, :referrer,
                                         :user_agent].include?(mapped_field)
                                   # we've excluded any fields that appear to
                                   # have their default unmapped values
@@ -80,6 +81,6 @@ module Rakismet
           akismet
         end
     end
-    
+
   end
 end

--- a/spec/models/custom_params_spec.rb
+++ b/spec/models/custom_params_spec.rb
@@ -1,7 +1,8 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 MAPPED_PARAMS = { :comment_type => :type2, :author => :author2, :content => :content2,
-                  :author_email => :author_email2, :author_url => :author_url2 }
+                  :author_email => :author_email2, :author_url => :author_url2,
+                  :user_role => :user_role2 }
 
 class CustomAkismetModel
   include Rakismet::Model
@@ -11,7 +12,7 @@ end
 
 describe CustomAkismetModel do
   it "should override default mappings" do
-    [:comment_type, :author, :author_url, :author_email, :content].each do |field|
+    [:comment_type, :author, :author_url, :author_email, :content, :user_role].each do |field|
       fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
        CustomAkismetModel.akismet_attrs[fieldname].should eql(MAPPED_PARAMS[field])
      end

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -8,7 +8,7 @@ describe AkismetModel do
   end
 
   it "should have default mappings" do
-    [:comment_type, :author, :author_email, :author_url, :content].each do |field|
+    [:comment_type, :author, :author_email, :author_url, :content, :user_role].each do |field|
       fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
       AkismetModel.akismet_attrs[fieldname].should eql(field)
      end


### PR DESCRIPTION
Another released, but not yet documented, feature for is the `user_role`
attribute. Specifically this can be used when testing the API and you
need to ensure the response is ham.

From my conversation with Akismet engineers:

> To simulate a negative (not spam) result, make a `comment-check` API call with the `user_role` set to "**administrator**", and all other required fields populated with typical values. The Akismet API will always return a `false` response. Any other response indicates a data or communication problem.
