### PR TITLE
Fix permalink sending

### DIFF
--- a/lib/rakismet/model.rb
+++ b/lib/rakismet/model.rb
@@ -14,12 +14,12 @@ module Rakismet
     module ClassMethods
       def rakismet_attrs(args={})
         self.akismet_attrs ||= {}
-        [:comment_type, :author, :author_url, :author_email, :content, :user_role, :permalink].each do |field|
+        [:comment_type, :author, :author_url, :author_email, :content, :user_role].each do |field|
           # clunky, but throwing around +type+ will break your heart
           fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
           self.akismet_attrs[fieldname] = args.delete(field) || field
         end
-        [:user_ip, :user_agent, :referrer].each do |field|
+        [:user_ip, :user_agent, :referrer, :permalink].each do |field|
           self.akismet_attrs[field] = args.delete(field) || field
         end
         args.each_pair do |f,v|

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -4,7 +4,7 @@ describe AkismetModel do
 
   before do
     @model = AkismetModel.new
-    comment_attrs.each_pair { |k,v| @model.stub!(k).and_return(v) }
+    comment_attrs.each_pair { |k,v| @model.stub(k).and_return(v) }
   end
 
   it "should have default mappings" do
@@ -30,7 +30,7 @@ describe AkismetModel do
       [:user_ip, :user_agent, :referrer].each do |field|
         @model.should_not respond_to(:field)
       end
-      Rakismet.stub!(:request).and_return(request)
+      Rakismet.stub(:request).and_return(request)
       Rakismet.should_receive(:akismet_call).
                 with('comment-check', akismet_attrs.merge(:user_ip => '127.0.0.1',
                                                           :user_agent => 'RSpec',
@@ -39,7 +39,7 @@ describe AkismetModel do
     end
 
     it "should send http_headers from Rakismet.request if present" do
-      Rakismet.stub!(:request).and_return(request_with_headers)
+      Rakismet.stub(:request).and_return(request_with_headers)
       Rakismet.should_receive(:akismet_call).
                 with('comment-check', akismet_attrs.merge(:user_ip => '127.0.0.1',
                                                           :user_agent => 'RSpec',
@@ -56,23 +56,23 @@ describe AkismetModel do
     end
 
     it "should be true if comment is spam" do
-      Rakismet.stub!(:akismet_call).and_return('true')
+      Rakismet.stub(:akismet_call).and_return('true')
       @model.should be_spam
     end
 
     it "should be false if comment is not spam" do
-      Rakismet.stub!(:akismet_call).and_return('false')
+      Rakismet.stub(:akismet_call).and_return('false')
       @model.should_not be_spam
     end
 
     it "should set akismet_response" do
-      Rakismet.stub!(:akismet_call).and_return('response')
+      Rakismet.stub(:akismet_call).and_return('response')
       @model.spam?
       @model.akismet_response.should eql('response')
     end
 
     it "should not throw an error if request vars are missing" do
-      Rakismet.stub!(:request).and_return(empty_request)
+      Rakismet.stub(:request).and_return(empty_request)
       lambda { @model.spam? }.should_not raise_error(NoMethodError)
     end
   end
@@ -85,7 +85,7 @@ describe AkismetModel do
     end
 
     it "should mutate #spam?" do
-      Rakismet.stub!(:akismet_call)
+      Rakismet.stub(:akismet_call)
       @model.instance_variable_set(:@_spam, false)
       @model.spam!
       @model.should be_spam
@@ -99,7 +99,7 @@ describe AkismetModel do
     end
 
     it "should mutate #spam?" do
-      Rakismet.stub!(:akismet_call)
+      Rakismet.stub(:akismet_call)
       @model.instance_variable_set(:@_spam, true)
       @model.ham!
       @model.should_not be_spam

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -8,14 +8,14 @@ describe AkismetModel do
   end
 
   it "should have default mappings" do
-    [:comment_type, :author, :author_email, :author_url, :content, :user_role, :permalink].each do |field|
+    [:comment_type, :author, :author_email, :author_url, :content, :user_role].each do |field|
       fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
       AkismetModel.akismet_attrs[fieldname].should eql(field)
      end
   end
 
   it "should have request mappings" do
-    [:user_ip, :user_agent, :referrer].each do |field|
+    [:user_ip, :user_agent, :referrer, :permalink].each do |field|
       AkismetModel.akismet_attrs[field].should eql(field)
      end
   end


### PR DESCRIPTION
Commit 81460d2 added the sending of permalink to Akismet by adding it to the list of "default mappings" all of which get `comment_` prepended. However, according to the Askismet documentation[1](http://akismet.com/development/api/#comment-check), it appears that they expect `permalink` to be simply `permalink` and not `comment_permalink`.

This commit fixes this discrepancy by moving the `:permalink` symbol from the list of attributes that receives the prepended `comment_` to the list of attributes that does not receive this prependage.
