### PR TITLE
Set akismet_response for spam! and ham!

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If you want to see what's happening behind the scenes, after you call one of
 
 This will contain the last response from the Akismet server. In the case of
 `spam?` it should be `true` or `false.` For `spam!` and `ham!` it should be
-`Feedback received.` If Akismet returned an error instead (e.g. if you left out
+`Thanks for making the web a better place.` If Akismet returned an error instead (e.g. if you left out
 some required information) this will contain the error message.
 
 FAQ

--- a/lib/rakismet/model.rb
+++ b/lib/rakismet/model.rb
@@ -45,12 +45,12 @@ module Rakismet
       end
 
       def spam!
-        Rakismet.akismet_call('submit-spam', akismet_data)
+        self.akismet_response = Rakismet.akismet_call('submit-spam', akismet_data)
         @_spam = true
       end
 
       def ham!
-        Rakismet.akismet_call('submit-ham', akismet_data)
+        self.akismet_response = Rakismet.akismet_call('submit-ham', akismet_data)
         @_spam = false
       end
 

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -90,6 +90,12 @@ describe AkismetModel do
       @model.spam!
       @model.should be_spam
     end
+
+    it "should set akismet response" do
+      Rakismet.stub!(:akismet_call).and_return('response')
+      @model.spam!
+      @model.akismet_response.should eql('response')
+    end
   end
 
   describe ".ham!" do
@@ -103,6 +109,12 @@ describe AkismetModel do
       @model.instance_variable_set(:@_spam, true)
       @model.ham!
       @model.should_not be_spam
+    end
+
+    it "should set akismet response" do
+      Rakismet.stub!(:akismet_call).and_return('response')
+      @model.ham!
+      @model.akismet_response.should eql('response')
     end
   end
 


### PR DESCRIPTION
I notice you're not assigning the response back to <code>@model.akismet_response</code> when calling <code>spam!</code> or <code>ham!</code>. This was mentioned in the README so I added the implementation for it.
