### PR TITLE
Making Rakismet Thread-safe

### DIFF
--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -13,34 +13,43 @@ module Rakismet
   Undefined = Class.new(NameError)
 
   class << self
-    attr_accessor :key, :url, :host, :proxy_host, :proxy_port, :test, :excluded_headers
-    
+    [:key, :url, :host, :proxy_host, :proxy_port, :test, :excluded_headers].each do |accessor|
+      define_method accessor do
+        Thread.current[:"rakismet_#{accessor}"]
+      end
+
+      define_method :"#{accessor}=" do |new_val|
+        Thread.current[:"rakismet_#{accessor}"] = new_val
+      end
+    end
+
     def excluded_headers
-      @excluded_headers || ['HTTP_COOKIE']
+      Thread.current[:rakismet_excluded_headers] || ['HTTP_COOKIE']
     end
 
     def request
-      @request ||= Request.new
+      Thread.current[:rakismet_request] ||= Request.new
     end
 
     def url
-      @url.is_a?(Proc) ? @url.call : @url
+      rakismet_url = Thread.current[:rakismet_url]
+      rakismet_url.is_a?(Proc) ? rakismet_url.call : rakismet_url
     end
 
     def set_request_vars(env)
       request.user_ip, request.user_agent, request.referrer =
         env['REMOTE_ADDR'], env['HTTP_USER_AGENT'], env['HTTP_REFERER']
-        
+
       # Collect all CGI-style HTTP_ headers except cookies for privacy..
       request.http_headers = env.select { |k,v| k =~ /^HTTP_/ }.reject { |k,v| excluded_headers.include? k }
     end
 
     def clear_request
-      @request = Request.new
+      Thread.current[:rakismet_request] = Request.new
     end
 
     def headers
-      @headers ||= begin
+      Thead.current[:rakismet_headers] ||= begin
         user_agent = "Rakismet/#{Rakismet::VERSION}"
         user_agent = "Rails/#{Rails.version} | " + user_agent if defined?(Rails)
         { 'User-Agent' => user_agent, 'Content-Type' => 'application/x-www-form-urlencoded' }
@@ -54,11 +63,11 @@ module Rakismet
         data = "key=#{Rakismet.key}&blog=#{Rakismet.url}"
         http.post(akismet.path, data, Rakismet.headers)
       end
-      @valid_key = (response.body == 'valid')
+      Thread.current[:rakismet_valid_key] = (response.body == 'valid')
     end
 
     def valid_key?
-      @valid_key == true
+      Thread.current[:rakismet_valid_key] == true
     end
 
     def akismet_call(function, args={})

--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -49,7 +49,7 @@ module Rakismet
     end
 
     def headers
-      Thead.current[:rakismet_headers] ||= begin
+      Thread.current[:rakismet_headers] ||= begin
         user_agent = "Rakismet/#{Rakismet::VERSION}"
         user_agent = "Rails/#{Rails.version} | " + user_agent if defined?(Rails)
         { 'User-Agent' => user_agent, 'Content-Type' => 'application/x-www-form-urlencoded' }

--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -13,18 +13,10 @@ module Rakismet
   Undefined = Class.new(NameError)
 
   class << self
-    [:key, :url, :host, :proxy_host, :proxy_port, :test, :excluded_headers].each do |accessor|
-      define_method accessor do
-        Thread.current[:"rakismet_#{accessor}"]
-      end
-
-      define_method :"#{accessor}=" do |new_val|
-        Thread.current[:"rakismet_#{accessor}"] = new_val
-      end
-    end
+    attr_accessor :key, :url, :host, :proxy_host, :proxy_port, :test, :excluded_headers
 
     def excluded_headers
-      Thread.current[:rakismet_excluded_headers] || ['HTTP_COOKIE']
+      @excluded_headers || ['HTTP_COOKIE']
     end
 
     def request
@@ -32,8 +24,7 @@ module Rakismet
     end
 
     def url
-      rakismet_url = Thread.current[:rakismet_url]
-      rakismet_url.is_a?(Proc) ? rakismet_url.call : rakismet_url
+      @url.is_a?(Proc) ? @url.call : @url
     end
 
     def set_request_vars(env)

--- a/lib/rakismet/middleware.rb
+++ b/lib/rakismet/middleware.rb
@@ -11,6 +11,5 @@ module Rakismet
       Rakismet.clear_request
       response
     end
-
   end
 end

--- a/lib/rakismet/model.rb
+++ b/lib/rakismet/model.rb
@@ -82,6 +82,5 @@ module Rakismet
           akismet
         end
     end
-
   end
 end

--- a/lib/rakismet/version.rb
+++ b/lib/rakismet/version.rb
@@ -1,3 +1,3 @@
 module Rakismet
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/rakismet.gemspec
+++ b/rakismet.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "rakismet"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.11"
+  s.add_development_dependency "rspec", "~> 3.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/models/block_params_spec.rb
+++ b/spec/models/block_params_spec.rb
@@ -8,18 +8,17 @@ class BlockAkismetModel
 end
 
 describe BlockAkismetModel do
-
   before do
     @block = BlockAkismetModel.new
-    comment_attrs.each_pair { |k,v| @block.stub!(k).and_return(v) }
+    comment_attrs.each_pair { |k,v| allow(@block).to receive(k){v} }
   end
 
   it "should accept a block" do
-    BlockAkismetModel.akismet_attrs[:comment_author].should eql(PROC)
+    expect(BlockAkismetModel.akismet_attrs[:comment_author]).to eql(PROC)
   end
 
   it "should eval block with self = instance" do
     data = @block.send(:akismet_data)
-    data[:comment_author].should eql(comment_attrs[:author].reverse)
+    expect(data[:comment_author]).to eql(comment_attrs[:author].reverse)
   end
 end

--- a/spec/models/custom_params_spec.rb
+++ b/spec/models/custom_params_spec.rb
@@ -14,7 +14,7 @@ describe CustomAkismetModel do
   it "should override default mappings" do
     [:comment_type, :author, :author_url, :author_email, :content, :user_role, :permalink].each do |field|
       fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
-       CustomAkismetModel.akismet_attrs[fieldname].should eql(MAPPED_PARAMS[field])
+       expect(CustomAkismetModel.akismet_attrs[fieldname]).to eql(MAPPED_PARAMS[field])
      end
   end
 end

--- a/spec/models/extended_params_spec.rb
+++ b/spec/models/extended_params_spec.rb
@@ -10,7 +10,7 @@ end
 describe ExtendedAkismetModel do
   it "should include additional attributes" do
     [:extra, :another].each do |field|
-      ExtendedAkismetModel.akismet_attrs[field].should eql(EXTRA[field])
+      expect(ExtendedAkismetModel.akismet_attrs[field]).to eql(EXTRA[field])
     end
   end
 end

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -4,33 +4,33 @@ describe AkismetModel do
 
   before do
     @model = AkismetModel.new
-    comment_attrs.each_pair { |k,v| @model.stub!(k).and_return(v) }
+    comment_attrs.each_pair { |k,v| allow(@model).to receive(k){v} }
   end
 
   it "should have default mappings" do
     [:comment_type, :author, :author_email, :author_url, :content, :user_role, :permalink].each do |field|
       fieldname = field.to_s =~ %r(^comment_) ? field : "comment_#{field}".intern
-      AkismetModel.akismet_attrs[fieldname].should eql(field)
+      expect(AkismetModel.akismet_attrs[fieldname]).to eql(field)
      end
   end
 
   it "should have request mappings" do
     [:user_ip, :user_agent, :referrer].each do |field|
-      AkismetModel.akismet_attrs[field].should eql(field)
+      expect(AkismetModel.akismet_attrs[field]).to eql(field)
      end
   end
 
   it "should populate comment type" do
-    @model.send(:akismet_data)[:comment_type].should == comment_attrs[:comment_type]
+    expect(@model.send(:akismet_data)[:comment_type]).to eql(comment_attrs[:comment_type])
   end
 
   describe ".spam?" do
 
     it "should use request variables from Rakismet.request if absent in model" do
       [:user_ip, :user_agent, :referrer].each do |field|
-        @model.should_not respond_to(:field)
+        expect(@model).not_to respond_to(:field)
       end
-      Rakismet.stub!(:request).and_return(request)
+      Rakismet.stub(:request).and_return(request)
       Rakismet.should_receive(:akismet_call).
                 with('comment-check', akismet_attrs.merge(:user_ip => '127.0.0.1',
                                                           :user_agent => 'RSpec',
@@ -39,8 +39,8 @@ describe AkismetModel do
     end
 
     it "should send http_headers from Rakismet.request if present" do
-      Rakismet.stub!(:request).and_return(request_with_headers)
-      Rakismet.should_receive(:akismet_call).
+      allow(Rakismet).to receive(:request) {request_with_headers}
+      expect(Rakismet).to receive(:akismet_call).
                 with('comment-check', akismet_attrs.merge(:user_ip => '127.0.0.1',
                                                           :user_agent => 'RSpec',
                                                           :referrer => 'http://test.host/referrer',
@@ -56,24 +56,25 @@ describe AkismetModel do
     end
 
     it "should be true if comment is spam" do
-      Rakismet.stub!(:akismet_call).and_return('true')
-      @model.should be_spam
+      Rakismet.stub(:akismet_call).and_return('true')
+      expect(@model).to be_spam
     end
 
     it "should be false if comment is not spam" do
-      Rakismet.stub!(:akismet_call).and_return('false')
-      @model.should_not be_spam
+      Rakismet.stub(:akismet_call).and_return('false')
+      expect(@model).not_to be_spam
     end
 
     it "should set akismet_response" do
-      Rakismet.stub!(:akismet_call).and_return('response')
+      Rakismet.stub(:akismet_call).and_return('response')
       @model.spam?
-      @model.akismet_response.should eql('response')
+      expect(@model.akismet_response).to eql('response')
     end
 
     it "should not throw an error if request vars are missing" do
-      Rakismet.stub!(:request).and_return(empty_request)
-      lambda { @model.spam? }.should_not raise_error(NoMethodError)
+      pending "Trying to figure out how to rewrite this or if it's even still correct"
+      Rakismet.stub(:request).and_return(empty_request)
+      expect{ @model.spam? }.not_to raise_error
     end
   end
 
@@ -85,10 +86,10 @@ describe AkismetModel do
     end
 
     it "should mutate #spam?" do
-      Rakismet.stub!(:akismet_call)
+      Rakismet.stub(:akismet_call)
       @model.instance_variable_set(:@_spam, false)
       @model.spam!
-      @model.should be_spam
+      expect(@model).to be_spam
     end
   end
 
@@ -99,11 +100,10 @@ describe AkismetModel do
     end
 
     it "should mutate #spam?" do
-      Rakismet.stub!(:akismet_call)
+      Rakismet.stub(:akismet_call)
       @model.instance_variable_set(:@_spam, true)
       @model.ham!
-      @model.should_not be_spam
+      expect(@model).not_to be_spam
     end
   end
-
 end

--- a/spec/models/rakismet_model_spec.rb
+++ b/spec/models/rakismet_model_spec.rb
@@ -30,8 +30,8 @@ describe AkismetModel do
       [:user_ip, :user_agent, :referrer].each do |field|
         expect(@model).not_to respond_to(:field)
       end
-      Rakismet.stub(:request).and_return(request)
-      Rakismet.should_receive(:akismet_call).
+      allow(Rakismet).to receive(:request){request}
+      expect(Rakismet).to receive(:akismet_call).
                 with('comment-check', akismet_attrs.merge(:user_ip => '127.0.0.1',
                                                           :user_agent => 'RSpec',
                                                           :referrer => 'http://test.host/referrer'))
@@ -72,7 +72,6 @@ describe AkismetModel do
     end
 
     it "should not throw an error if request vars are missing" do
-      pending "Trying to figure out how to rewrite this or if it's even still correct"
       Rakismet.stub(:request).and_return(empty_request)
       expect{ @model.spam? }.not_to raise_error
     end

--- a/spec/models/request_params_spec.rb
+++ b/spec/models/request_params_spec.rb
@@ -9,7 +9,7 @@ describe RequestParams do
     before do
       @model = RequestParams.new
       attrs = comment_attrs(:user_ip => '192.168.0.1', :user_agent => 'Rakismet', :referrer => 'http://localhost/referrer')
-      attrs.each_pair { |k,v| @model.stub!(k).and_return(v) }
+      attrs.each_pair { |k,v| @model.stub(k).and_return(v) }
     end
 
   it "should use local values even if Rakismet.request is populated" do

--- a/spec/models/subclass_spec.rb
+++ b/spec/models/subclass_spec.rb
@@ -5,10 +5,10 @@ end
 
 describe Subclass do
   it "should inherit parent's rakismet attrs" do
-    Subclass.akismet_attrs.should eql AkismetModel.akismet_attrs # key/value equality
+    expect(Subclass.akismet_attrs).to eql(AkismetModel.akismet_attrs) # key/value equality
   end
 
   it "should get a new copy of parent's rakismet attrs" do
-    Subclass.akismet_attrs.should_not equal AkismetModel.akismet_attrs # object equality
+    expect(Subclass.akismet_attrs).not_to equal(AkismetModel.akismet_attrs) # object equality
   end
 end

--- a/spec/rakismet_middleware_spec.rb
+++ b/spec/rakismet_middleware_spec.rb
@@ -26,10 +26,9 @@ describe Rakismet::Middleware do
 
   it "should clear Rakismet.request after request is complete" do
     @middleware.call(env)
-    Rakismet.request.user_ip.should be_nil
-    Rakismet.request.user_agent.should be_nil
-    Rakismet.request.referrer.should be_nil
-    Rakismet.request.http_headers.should be_nil
+    expect(Rakismet.request.user_ip).to be_nil
+    expect(Rakismet.request.user_agent).to be_nil
+    expect(Rakismet.request.referrer).to be_nil
+    expect(Rakismet.request.http_headers).to be_nil
   end
-  
 end

--- a/spec/rakismet_spec.rb
+++ b/spec/rakismet_spec.rb
@@ -15,64 +15,64 @@ describe Rakismet do
 
   describe "proxy host" do
     it "should have proxy host and port as nil by default" do
-      Rakismet.proxy_host.should be_nil
-      Rakismet.proxy_port.should be_nil
+      expect(Rakismet.proxy_host).to be_nil
+      expect(Rakismet.proxy_port).to be_nil
     end
   end
 
   describe "url" do
     it "should allow url to be a string" do
       Rakismet.url = "string.example.com"
-      Rakismet.url.should eql("string.example.com")
+      expect(Rakismet.url).to eql("string.example.com")
     end
 
     it "should allow url to be a proc" do
       Rakismet.url = Proc.new { "proc.example.com" }
-      Rakismet.url.should eql("proc.example.com")
+      expect(Rakismet.url).to eql("proc.example.com")
     end
   end
 
   describe ".validate_config" do
     it "should raise an error if key is not found" do
       Rakismet.key = ''
-      lambda { Rakismet.send(:validate_config) }.should raise_error(Rakismet::Undefined)
+      expect{ Rakismet.send(:validate_config) }.to raise_error(Rakismet::Undefined)
     end
 
     it "should raise an error if url is not found" do
       Rakismet.url = ''
-      lambda { Rakismet.send(:validate_config) }.should raise_error(Rakismet::Undefined)
+      expect{ Rakismet.send(:validate_config) }.to raise_error(Rakismet::Undefined)
     end
 
     it "should raise an error if host is not found" do
       Rakismet.host = ''
-      lambda { Rakismet.send(:validate_config) }.should raise_error(Rakismet::Undefined)
+      expect{ Rakismet.send(:validate_config) }.to raise_error(Rakismet::Undefined)
     end
   end
 
   describe ".validate_key" do
     before (:each) do
-      @proxy = mock(Net::HTTP)
-      Net::HTTP.stub!(:Proxy).and_return(@proxy)
+      @proxy = double(Net::HTTP)
+      Net::HTTP.stub(:Proxy).and_return(@proxy)
     end
 
     it "should use proxy host and port" do
       Rakismet.proxy_host = 'proxy_host'
       Rakismet.proxy_port = 'proxy_port'
-      @proxy.stub!(:start).and_return(mock_response('valid'))
+      @proxy.stub(:start).and_return(mock_response('valid'))
       Net::HTTP.should_receive(:Proxy).with('proxy_host', 'proxy_port').and_return(@proxy)
       Rakismet.validate_key
     end
 
     it "should set @@valid_key = true if key is valid" do
-      @proxy.stub!(:start).and_return(mock_response('valid'))
+      @proxy.stub(:start).and_return(mock_response('valid'))
       Rakismet.validate_key
-      Rakismet.valid_key?.should be_true
+      expect(Rakismet.valid_key?).to be true
     end
 
     it "should set @@valid_key = false if key is invalid" do
-      @proxy.stub!(:start).and_return(mock_response('invalid'))
+      @proxy.stub(:start).and_return(mock_response('invalid'))
       Rakismet.validate_key
-      Rakismet.valid_key?.should be_false
+      expect(Rakismet.valid_key?).to be false
     end
 
     it "should build url with host" do
@@ -82,24 +82,24 @@ describe Rakismet do
       Rakismet.validate_key
     end
   end
-  
+
   describe '.excluded_headers' do
     it "should default to ['HTTP_COOKIE']" do
-      Rakismet.excluded_headers.should eq ['HTTP_COOKIE']
+      expect(Rakismet.excluded_headers).to eq ['HTTP_COOKIE']
     end
   end
 
   describe ".akismet_call" do
     before do
-      @proxy = mock(Net::HTTP)
-      Net::HTTP.stub!(:Proxy).and_return(@proxy)
+      @proxy = double(Net::HTTP)
+      Net::HTTP.stub(:Proxy).and_return(@proxy)
       @proxy.stub(:start).and_yield(http)
     end
 
     it "should use proxy host and port" do
       Rakismet.proxy_host = 'proxy_host'
       Rakismet.proxy_port = 'proxy_port'
-      @proxy.stub!(:start).and_return(mock_response('valid'))
+      @proxy.stub(:start).and_return(mock_response('valid'))
       Net::HTTP.should_receive(:Proxy).with('proxy_host', 'proxy_port').and_return(@proxy)
       Rakismet.send(:akismet_call, 'bogus-function')
     end
@@ -128,13 +128,11 @@ describe Rakismet do
     end
 
     it "should return response.body" do
-      Rakismet.send(:akismet_call, 'bogus-function').should eql('akismet response')
+      expect(Rakismet.send(:akismet_call, 'bogus-function')).to eql('akismet response')
     end
 
     it "should build query string when params are nil" do
-      lambda {
-        Rakismet.send(:akismet_call, 'bogus-function', { :nil_param => nil })
-      }.should_not raise_error(NoMethodError)
+      expect{Rakismet.send(:akismet_call, 'bogus-function', { :nil_param => nil })}.not_to raise_error
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,12 @@ require 'ostruct'
 
 RSpec.configure do |config|
   config.mock_with :rspec
+
+  config.before(:all) do
+    Rakismet.key = '123'
+    Rakismet.url = 'http://test.host'
+    Rakismet.host = 'rest.akismet.com'
+  end
 end
 
 class AkismetModel
@@ -31,7 +37,7 @@ def request_with_headers
   OpenStruct.new(:user_ip => '127.0.0.1',
                  :user_agent => 'RSpec',
                  :referrer => 'http://test.host/referrer',
-                 :http_headers => { 'HTTP_USER_AGENT' => 'RSpec', 'HTTP_REFERER' => 'http://test.host/referrer' } )  
+                 :http_headers => { 'HTTP_USER_AGENT' => 'RSpec', 'HTTP_REFERER' => 'http://test.host/referrer' } )
 end
 
 def empty_request


### PR DESCRIPTION
While investigating Rakismet to see how it obtained the request-related information, I noticed that a lot of the information was being stored in non-thread-safe class instance variables. Considering the larger number of people deploying onto Puma and other thread-capable servers nowadays, this seems like a large omission.

So here's a change set to store the request and responses in Thread-local variables to keep thread safety.

The tests also still pass, a large majority of them are now rewritten to use expect/allow from rspec 3.
