### PR TITLE
Adds Proc support to #key, #host

### DIFF
--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -23,8 +23,16 @@ module Rakismet
       @request ||= Request.new
     end
 
+    def key
+      @key.is_a?(Proc) ? @key.call : @key
+    end
+    
     def url
       @url.is_a?(Proc) ? @url.call : @url
+    end
+    
+    def host
+      @host.is_a?(Proc) ? @host.call : @host
     end
 
     def set_request_vars(env)


### PR DESCRIPTION
This change allows the Akismet key and host to be provided in Procs as each tenant in the multi-tenant application may be provisioning their own Akismet account.
