### PR TITLE
Fixing a bug where Rails.version is potentially undefined.

### DIFF
--- a/lib/rakismet.rb
+++ b/lib/rakismet.rb
@@ -42,7 +42,11 @@ module Rakismet
     def headers
       @headers ||= begin
         user_agent = "Rakismet/#{Rakismet::VERSION}"
-        user_agent = "Rails/#{Rails.version} | " + user_agent if defined?(Rails)
+
+        if defined?(Rails) && Rails.respond_to?(:version)
+          user_agent = "Rails/#{Rails.version} | " + user_agent
+        end
+
         { 'User-Agent' => user_agent, 'Content-Type' => 'application/x-www-form-urlencoded' }
       end
     end


### PR DESCRIPTION
Fixes #41 If a user is using certain gems (ActiveRecord, ActionMailer, etc) without the rails gem, in a standalone application, they encounter a situation where the Rails module is defined but doesn't have a version method, so improve the check before adding Rails.version to the headers.